### PR TITLE
Resolve peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "typescript": "^2.6.1"
   },
   "peerDependencies": {
-    "react": "^15.6.1",
-    "react-native": "^0.45.1"
+    "react": ">15.6.1",
+    "react-native": ">0.45.1"
   },
   "dependencies": {
     "@types/prop-types": "^15.5.2",


### PR DESCRIPTION
Resolves peer dependency warnings when using React 16, or higher versions of React Native